### PR TITLE
Change to standard-compliant assignment operators

### DIFF
--- a/h5xx/attribute/attribute.hpp
+++ b/h5xx/attribute/attribute.hpp
@@ -45,7 +45,7 @@ public:
      * with "attribute h5xx::move(attribute&)", i.e., the attribute object on the right
      * hand side is empty after move assignment.
      */
-    attribute const& operator=(attribute other);
+    attribute & operator=(attribute other);
 
     /** default destructor */
     ~attribute();
@@ -142,7 +142,7 @@ inline attribute::attribute(attribute const& other)
     H5Iinc_ref(hid_);
 }
 
-inline attribute const& attribute::operator=(attribute other)
+inline attribute & attribute::operator=(attribute other)
 {
     swap(*this, other);
     return *this;

--- a/h5xx/dataset/dataset.hpp
+++ b/h5xx/dataset/dataset.hpp
@@ -58,7 +58,7 @@ public:
      * with "dataset h5xx::move(dataset&)", i.e., the dataset object on the right
      * hand side is empty after move assignment.
      */
-    dataset const& operator=(dataset other);
+    dataset & operator=(dataset other);
 
     /** deduce dataspace from dataset */
     operator dataspace() const;
@@ -164,7 +164,7 @@ inline dataset::dataset(dataset const& other)
     H5Iinc_ref(hid_);
 }
 
-inline dataset const& dataset::operator=(dataset other)
+inline dataset & dataset::operator=(dataset other)
 {
     swap(*this, other);
     return *this;

--- a/h5xx/dataspace/dataspace.hpp
+++ b/h5xx/dataspace/dataspace.hpp
@@ -89,7 +89,7 @@ public:
      * with "dataspace h5xx::move(dataspace&)", i.e., the dataspace object on the right
      * hand side is empty after move assignment.
      */
-    dataspace const& operator=(dataspace other);
+    dataspace & operator=(dataspace other);
 
     /** default destructor */
     ~dataspace();
@@ -171,7 +171,7 @@ inline dataspace::dataspace(dataspace const& other)
     H5Iinc_ref(hid_);
 }
 
-inline dataspace const& dataspace::operator=(dataspace other)
+inline dataspace & dataspace::operator=(dataspace other)
 {
     swap(*this, other);
     return *this;

--- a/h5xx/file.hpp
+++ b/h5xx/file.hpp
@@ -88,7 +88,7 @@ public:
      * with "file h5xx::move(file&)", i.e., the group object on the right
      * hand side is empty after move assignment.
      */
-    file const& operator=(file other);
+    file & operator=(file other);
 
     /** close file upon destruction */
     ~file();
@@ -156,7 +156,7 @@ inline file::file(file const& other)
     plid_ = H5Fget_access_plist(hid_);
 }
 
-inline file const& file::operator=(file other)
+inline file & file::operator=(file other)
 {
     swap(*this, other);
     return *this;

--- a/h5xx/group.hpp
+++ b/h5xx/group.hpp
@@ -49,7 +49,7 @@ public:
      * with "group h5xx::move(group&)", i.e., the group object on the right
      * hand side is empty after move assignment.
      */
-    group const& operator=(group other);
+    group & operator=(group other);
 
     /** default destructor */
     ~group();
@@ -107,7 +107,7 @@ inline group::group(group const& other)
     H5Iinc_ref(hid_);
 }
 
-inline group const& group::operator=(group other)
+inline group & group::operator=(group other)
 {
     swap(*this, other);
     return *this;


### PR DESCRIPTION
Found with Clang-Tidy while preparing https://github.com/espressomd/espresso/pull/1683

```
espresso/libs/h5xx/h5xx/attribute/attribute.hpp:48:5: error: operator=() should return 'attribute&' [misc-unconventional-assign-operator,-warnings-as-errors]
    attribute const& operator=(attribute other);
    ^
espresso/libs/h5xx/h5xx/attribute/attribute.hpp:145:1: error: operator=() should return 'attribute&' [misc-unconventional-assign-operator,-warnings-as-errors]
inline attribute const& attribute::operator=(attribute other)
^
```